### PR TITLE
Fix empty values for barlist

### DIFF
--- a/outputformat/plot.py
+++ b/outputformat/plot.py
@@ -120,25 +120,28 @@ def bar(
             empty = " " * len(str(style))
             end = "]"
 
-    ratio = value / maxvalue
-    nfill = int(ratio * length)
-
     # Start outputstring
     outputstring = ""
     if title:
         title = str(title)
 
         outputstring += f"{title:.<{title_pad}}: "
-    outputstring += start
-    outputstring += f"{fill*nfill}{empty*(length-nfill)}"
-    outputstring += end
 
-    if show_values:
-        values_pad += values_precision + 1
-        outputstring += f" {value:>{values_pad}.{values_precision}f}/{maxvalue:.{values_precision}f}"
+    # Check if it's not a NaN
+    if value == value:
 
-    if show_percentage:
-        outputstring += f" ({value/maxvalue:>7.2%})"
+        ratio = value / maxvalue
+        nfill = int(ratio * length)
+        outputstring += start
+        outputstring += f"{fill*nfill}{empty*(length-nfill)}"
+        outputstring += end
+
+        if show_values:
+            values_pad += values_precision + 1
+            outputstring += f" {value:>{values_pad}.{values_precision}f}/{maxvalue:.{values_precision}f}"
+
+        if show_percentage:
+            outputstring += f" ({value/maxvalue:>7.2%})"
 
     if return_str:
         return outputstring
@@ -239,6 +242,8 @@ def barlist(
     if not maxvalue:
         maxvalue = max(values)
 
+    # Convert all titles to strings
+    titles = [str(t) for t in titles]
     # Get the longest title to use the proper padding
     longest_title = len(max(titles, key=len))
 

--- a/outputformat/plot.py
+++ b/outputformat/plot.py
@@ -73,7 +73,7 @@ def bar(
     """
 
     # Check if value < maxvalue
-    if value > maxvalue:
+    if value and value > maxvalue:
         raise ValueError(f"'value' cannot be bigger than 'maxvalue' {emoji.crazy}")
 
     if style in ["block"]:
@@ -127,8 +127,8 @@ def bar(
 
         outputstring += f"{title:.<{title_pad}}: "
 
-    # Check if it's not a NaN
-    if value == value:
+    # Check if it's not a NaN or None
+    if value == value and value:
 
         ratio = value / maxvalue
         nfill = int(ratio * length)
@@ -224,12 +224,16 @@ def barlist(
         titles = [""] * len(values)
 
     # Negative values are not suported
-    if min(values) < 0:
-        raise ValueError("Negative values are not supported")
+    for value in values:
+        try:
+            if value < 0:
+                raise ValueError("Negative values are not supported")
+        except:
+            pass
 
     # Check if titles match values
     if len(values) != len(titles):
-        errormsg = f"'values' and 'titles' mus have the same length {emoji.sad}"
+        errormsg = f"'values' and 'titles' must have the same length {emoji.sad}"
         errormsg += f"\ntotal values: {len(values)}"
         errormsg += f"\ntotal titles: {len(titles)}"
         raise ValueError(errormsg)
@@ -240,7 +244,8 @@ def barlist(
     # In case maxvalue is no given,
     # uses the max from all the values
     if not maxvalue:
-        maxvalue = max(values)
+        # Get the max without breaking in case we find a "None"
+        maxvalue = max([v for v in values if v])
 
     # Convert all titles to strings
     titles = [str(t) for t in titles]


### PR DESCRIPTION
barlist was breaking in case NaNs or None was given. Now works as expected:

``` Python
values = [np.nan, 24, None, 10]
titles = ["VarA", np.nan, "VarCCCC", None]

ouf.barlist(values, titles=titles, maxvalue=100)
```
Gives as output:
```
VarA...: 
nan....: [■■■■■■■                         ]  24.00/100.00 ( 24.00%)
VarCCCC: 
None...: [■■■                             ]  10.00/100.00 ( 10.00%)

```