### PR TITLE
fix title length with ANSI escape sequences

### DIFF
--- a/outputformat/title.py
+++ b/outputformat/title.py
@@ -45,7 +45,7 @@ def linetitle(txt, style="-", color=False, cmap="cool", bold=False, return_str=F
     outputstring = ""
 
     txt = str(txt)
-    txt_size = len(txt)
+    txt_size = ouf.tools.real_string_length(txt)
     style = str(style)
 
     # bl = bottom left
@@ -114,7 +114,7 @@ def boxtitle(txt, style="-", return_str=False, color=False, cmap="cool", bold=Fa
     """
 
     txt = str(txt)
-    txt_size = len(txt)
+    txt_size = ouf.tools.real_string_length(txt)
     style = str(style)
 
     if style in ["line", "-"]:

--- a/outputformat/tools.py
+++ b/outputformat/tools.py
@@ -3,6 +3,7 @@ from outputformat.title import boxtitle
 from outputformat import emoji
 import colorsys
 from random import random
+from re import sub
 
 
 def prepare_data(input_data, precision):
@@ -203,3 +204,15 @@ def parse_color(color, cmap):
             color = (random(), default_saturation, 1)
 
     return color
+
+def real_string_length(txt):
+    """Compute the length of the strings without the ANSI escape sequences
+
+    Returns
+    -------
+    int
+        real length of the string txt
+
+    """
+    pattern = "\x1b\[[;\d]*m"
+    return len(sub(pattern,"",txt))


### PR DESCRIPTION
Compute real length of strings containing formatters to correctly print linetitle and boxtitle.

Before:
![Screenshot from 2022-02-23 10-54-10](https://user-images.githubusercontent.com/3923597/155296983-b7297888-376c-454c-ae24-5b43334d1ca9.png)
Now:
![Screenshot from 2022-02-23 10-57-17](https://user-images.githubusercontent.com/3923597/155297004-3f522014-6d9f-4df8-bf11-bc83dd172a00.png)

